### PR TITLE
update CSLreferences usage in line with upstream

### DIFF
--- a/inst/templates/yaac/yaac.tex
+++ b/inst/templates/yaac/yaac.tex
@@ -22,7 +22,7 @@ $if(csl-refs)$
 % For pandoc 2.11+ using new --citeproc
 \newlength{\csllabelwidth}
 \setlength{\csllabelwidth}{3em}
-\newenvironment{CSLReferences}[3] % #1 hanging-ident, #2 entry spacing
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
  {% don't indent paragraphs
   \setlength{\parindent}{0pt}
   % turn on hanging indent if param 1 is 1


### PR DESCRIPTION
fixes compliation error due to overflow in references section (this fix was implemented in the CV template last year when pandoc was updated). 